### PR TITLE
Add support for libvirt provider

### DIFF
--- a/builder/Vagrantfile
+++ b/builder/Vagrantfile
@@ -28,6 +28,12 @@ __EOF
 			v.memory = 4096
 			v.cpus = 2
 		end
+		b.vm.provider :libvirt do |v, o|
+			o.vm.box = "centos/7"
+			v.storage_pool_name = "images"
+			v.memory = 4096
+			v.cpus = 2
+		end
 		b.vm.host_name = "#{host_prefix}-builder.lfs.local"
 		# Admin / management network
 		b.vm.network "private_network",

--- a/hpc-storage-sandbox-el7/Vagrantfile
+++ b/hpc-storage-sandbox-el7/Vagrantfile
@@ -15,7 +15,17 @@ Vagrant.configure("2") do |config|
 	end
 
 	# Directory root for additional vdisks for MGT, MDT0, and OSTs
+	# XXX It would be nice to put this in the above provider block since
+	#     it really only applies for the vbox provider
 	vdisk_root = "#{ENV['HOME']}/VirtualBox\ VMs/vdisks"
+
+        # use the "images" storage pool
+	config.vm.provider :libvirt do |libvirt, override|
+		override.vm.box = "centos/7"
+		libvirt.storage_pool_name = "images"
+		libvirt.memory = 1024
+	end
+
 	# Number of shared disk devices per OSS server pair
 	sdnum=8
 
@@ -153,6 +163,22 @@ __EOF"
 					"--mtype", "shareable",
 					"--device", "0"]
 			end
+			mds.vm.provider :libvirt do |libvirt|
+				if mds_idx==1 # && not(File.exist?("#{vdisk_root}/mgs.vdi"))
+					libvirt.storage :file,
+							:size => '512M',
+							:path => 'mgs.img',
+							:allow_existing => true,
+							:shareable => true,
+							:type => 'raw'
+					libvirt.storage :file,
+							:size => '5120M',
+							:path => 'mdt0.img',
+							:allow_existing => true,
+							:shareable => true,
+							:type => 'raw'
+				end
+			end
 			# Set host name of VM
 			mds.vm.host_name = "#{host_prefix}-mds#{mds_idx}.lfs.local"
 			# Admin / management network
@@ -232,7 +258,20 @@ __EOF"
 						]
 				end
 			end
-
+			oss.vm.provider :libvirt do |libvirt|
+				osd_min = ((oss_idx-1) / 2) * sdnum
+				osd_max = osd_min + 7
+				if oss_idx % 2 == 1
+					(osd_min..osd_max).each do |ost|
+						libvirt.storage :file,
+								:size => '5120M',
+								:path => "ost#{ost}.img",
+								:allow_existing => true,
+								:shareable => true,
+								:type => 'raw'
+					end
+				end
+			end
 			oss.vm.host_name = "#{host_prefix}-oss#{oss_idx}.lfs.local"
 			# Admin / management network
 			oss.vm.network "private_network",

--- a/hpc-storage-sandbox-el7/Vagrantfile.2ndcontroller
+++ b/hpc-storage-sandbox-el7/Vagrantfile.2ndcontroller
@@ -63,7 +63,7 @@ __EOF
 	end
 	}
 	config.vm.provision "shell", inline: "cp -f /vagrant/hosts /etc/hosts"
-	config.vm.provision "shell", inline: "setenforce 0; cat >/etc/selinux/config<<__EOF
+	config.vm.provision "shell", inline: "selinuxenabled && setenforce 0; cat >/etc/selinux/config<<__EOF
 SELINUX=disabled
 SELINUXTYPE=targeted
 __EOF"
@@ -71,7 +71,7 @@ __EOF"
 	# A simple way to create a key that can be used to enable
 	# SSH between the virtual guests.
 	#
-	# The private key is copied onto the root account of the 
+	# The private key is copied onto the root account of the
 	# administration node and the public key is appended to the
 	# authorized_keys file of the root account for all nodes
 	# in the cluster.
@@ -217,7 +217,7 @@ __EOF"
 				# consecutive numbering. Each pair of servers has a set
 				# of shared virtual disks (vdisks) numbered in the range
 				# osd_min to osd_max. e.g.:
-				# oss{1,2} share OST0..OST7 and oss{3,4} share OST8..OST16, 
+				# oss{1,2} share OST0..OST7 and oss{3,4} share OST8..OST16,
 				# assuming the number of disks per pair (sdnum) is 8
 				osd_min = ((oss_idx-1) / 2) * sdnum
 				osd_max = osd_min + 7


### PR DESCRIPTION
This let's Linux use the native libvirt/kvm/qemu support rather than
requiring VirtualBox being installed.