### PR TITLE
Create IML sandbox Vagrantfile

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -15,13 +15,34 @@ LNET_PFX = "#{SUBNET_PREFIX}.20".freeze
 # get an IP assigned.
 xnet_idx = 230
 
-ISCI_IP = "#{LNET_PFX}.30".freeze
+ISCI_IP = "#{SUBNET_PREFIX}.40.10".freeze
 
-def provision_mdns(config)
+def provision_iscsi_net(config, num)
+  config.vm.network 'private_network',
+                    ip: "#{SUBNET_PREFIX}.40.#{num}",
+                    netmask: '255.255.255.0',
+                    virtualbox__intnet: 'iscsi-net'
+end
+
+def provision_lnet_net(config, num)
+  config.vm.network 'private_network',
+                    ip: "#{LNET_PFX}.#{num}",
+                    netmask: '255.255.255.0',
+                    virtualbox__intnet: 'lnet-net'
+end
+
+def provision_mgmt_net(config, num)
+  config.vm.network 'private_network',
+                    ip: "#{MGMT_NET_PFX}.#{num}",
+                    netmask: '255.255.255.0',
+                    virtualbox__intnet: 'adm-net'
+end
+
+def provision_mdns(config, iface)
   config.vm.provision 'mdns', type: 'shell', inline: <<-SHELL
     yum install -y epel-release
     yum install -y avahi nss-mdns
-    sed -i 's/myhostname/mdns/' /etc/nsswitch.conf
+    sed -i 's/^#allow-interfaces=.*/allow-interfaces=#{iface}/' /etc/avahi/avahi-daemon.conf
     systemctl restart network
     systemctl enable avahi-daemon.socket
     systemctl start avahi-daemon.socket
@@ -57,13 +78,15 @@ def fix_hostfile(config)
 end
 
 Vagrant.configure('2') do |config|
-  config.vm.box = 'manager-for-lustre/centos75-1804-base'
+  config.vm.box = 'centos/7'
 
   config.vm.provider 'virtualbox' do |vbx|
     vbx.linked_clone = true
     vbx.memory = 1024
     vbx.cpus = 4
   end
+
+  config.vm.provision 'deps', type: 'shell', inline: 'yum install -y jq htop'
 
   system("ssh-keygen -t rsa -N '' -f id_rsa") unless File.exist?('id_rsa')
 
@@ -82,7 +105,11 @@ __EOF
   SHELL
 
   config.vm.define 'iscsi' do |iscsi|
+    iscsi.vm.box = 'manager-for-lustre/centos75-1804-base'
     iscsi.vm.hostname = 'iscsi.local'
+
+    fix_hostfile iscsi
+    provision_iscsi_net iscsi, '10'
 
     iscsi.vm.provider 'virtualbox' do |vbx|
       dir = "#{ENV['HOME']}/VirtualBox\ VMs/vdisks"
@@ -121,11 +148,7 @@ __EOF
                        "VBoxInternal/Devices/ahci/0/Config/Port#{port}/SerialNumber",
                        name.ljust(20, '0')]
       end
-
-      # Lustre / application network
-      iscsi.vm.network 'private_network',
-                       ip: ISCI_IP,
-                       netmask: '255.255.255.0'
+    end
 
       ost_commands = ('d'..'z')
                      .take(20)
@@ -155,11 +178,6 @@ __EOF
         targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/acls create iqn.2015-01.com.whamcloud:oss2
         systemctl enable target
       SHELL
-
-      fix_hostfile iscsi
-
-      provision_mdns iscsi
-    end
   end
 
   #
@@ -172,13 +190,9 @@ __EOF
     adm.vm.network 'forwarded_port', guest: 8080, host: 8081
 
     # Admin / management network
-    adm.vm.network 'private_network',
-                   ip: "#{MGMT_NET_PFX}.10",
-                   netmask: '255.255.255.0'
+    provision_mgmt_net adm, '10'
 
-    fix_hostfile adm
-
-    provision_mdns adm
+    provision_mdns adm, 'eth1'
 
     # Install IML onto the admin node
     # This requires you have the IML source tree available at
@@ -200,22 +214,20 @@ __EOF
     config.vm.define "mds#{i}" do |mds|
       mds.vm.hostname = "mds#{i}.local"
 
-      # Lustre / application network
-      mds.vm.network 'private_network',
-                     ip: "#{LNET_PFX}.1#{i}",
-                     netmask: '255.255.255.0'
+      provision_lnet_net mds, "1#{i}"
 
       # Admin / management network
-      mds.vm.network 'private_network',
-                     ip: "#{MGMT_NET_PFX}.1#{i}",
-                     netmask: '255.255.255.0'
+      provision_mgmt_net mds, "1#{i}"
+
+      provision_iscsi_net mds, "1#{i}"
 
       # Private network to simulate crossover.
       # Used exclusively as additional cluster network
       mds.vm.network 'private_network',
                      ip: "#{SUBNET_PREFIX}.#{xnet_idx}.1#{i}",
                      netmask: '255.255.255.0',
-                     auto_config: false
+                     auto_config: false,
+                     virtualbox__intnet: "crossover-net#{xnet_idx}"
 
       # Increment the "crossover" subnet number so that
       # each HA pair has a unique "crossover" subnet
@@ -223,7 +235,7 @@ __EOF
 
       fix_hostfile mds
 
-      provision_mdns mds
+      provision_mdns mds, 'eth2'
 
       provision_iscsi_client mds, 'mds', i
 
@@ -245,21 +257,20 @@ __EOF
       oss.vm.hostname = "oss#{i}.local"
 
       # Lustre / application network
-      oss.vm.network 'private_network',
-                     ip: "#{LNET_PFX}.2#{i}",
-                     netmask: '255.255.255.0'
+      provision_lnet_net oss, "2#{i}"
 
       # Admin / management network
-      oss.vm.network 'private_network',
-                     ip: "#{MGMT_NET_PFX}.2#{i}",
-                     netmask: '255.255.255.0'
+      provision_mgmt_net oss, "2#{i}"
 
       # Private network to simulate crossover.
       # Used exclusively as additional cluster network
       oss.vm.network 'private_network',
                      ip: "#{SUBNET_PREFIX}.#{xnet_idx}.2#{i}",
                      netmask: '255.255.255.0',
-                     auto_config: false
+                     auto_config: false,
+                     virtualbox__intnet: "crossover-net#{xnet_idx}"
+
+      provision_iscsi_net oss, "2#{i}"
 
       # Increment the "crossover" subnet number so that
       # each HA pair has a unique "crossover" subnet
@@ -267,31 +278,27 @@ __EOF
 
       fix_hostfile oss
 
-      provision_mdns oss
-
-      cleanup_storage_server oss
+      provision_mdns oss, 'eth2'
 
       provision_iscsi_client oss, 'oss', i
+
+      cleanup_storage_server oss
     end
   end
 
-  # # Create a set of compute nodes.
-  # # By default, only 2 compute nodes are created.
-  # # The configuration supports a maximum of 8 compute nodes.
-  (1..8).each do |c_idx|
-    config.vm.define "c#{c_idx}",
-                     autostart: c_idx <= 2 do |c|
-      c.vm.hostname = "c#{c_idx}.local"
+  # Create a set of compute nodes.
+  # By default, only 2 compute nodes are created.
+  # The configuration supports a maximum of 8 compute nodes.
+  (1..8).each do |i|
+    config.vm.define "c#{i}",
+                     autostart: i <= 2 do |c|
+      c.vm.hostname = "c#{i}.local"
 
       # Admin / management network
-      c.vm.network 'private_network',
-                   ip: "#{MGMT_NET_PFX}.3#{c_idx}",
-                   netmask: '255.255.255.0'
+      provision_mgmt_net c, "3#{i}"
 
       # Lustre / application network
-      c.vm.network 'private_network',
-                   ip: "#{LNET_PFX}.3#{c_idx}",
-                   netmask: '255.255.255.0'
+      provision_lnet_net c, "3#{i}"
     end
   end
 end

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -1,0 +1,297 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Create a set of /24 networks under a single /16 subnet range
+SUBNET_PREFIX = '10.73'.freeze
+
+# Management network for admin comms
+MGMT_NET_PFX = "#{SUBNET_PREFIX}.10".freeze
+
+# Lustre / HPC network
+LNET_PFX = "#{SUBNET_PREFIX}.20".freeze
+
+# Subnet index used to create cross-over nets for each HA cluster pair
+# This currently appears to be pointless as unmanaged networks don't
+# get an IP assigned.
+xnet_idx = 230
+
+ISCI_IP = "#{LNET_PFX}.30".freeze
+
+def provision_mdns(config)
+  config.vm.provision 'mdns', type: 'shell', inline: <<-SHELL
+    yum install -y epel-release
+    yum install -y avahi nss-mdns
+    sed -i 's/myhostname/mdns/' /etc/nsswitch.conf
+    systemctl restart network
+    systemctl enable avahi-daemon.socket
+    systemctl start avahi-daemon.socket
+    systemctl start avahi-daemon.service
+    systemctl status avahi-daemon.service
+  SHELL
+end
+
+def cleanup_storage_server(config)
+  config.vm.provision 'cleanup', type: 'shell', run: 'never', inline: <<-SHELL
+    yum autoremove -y chroma-agent
+    rm -rf /etc/iml
+    rm -rf /var/lib/{chroma,iml}
+    rm -rf /etc/yum.repos.d/Intel-Lustre-Agent.repo
+  SHELL
+end
+
+def provision_iscsi_client(config, name, idx)
+  config.vm.provision 'iscsi-client', type: 'shell', inline: <<-SHELL
+    yum -y install iscsi-initiator-utils lsscsi
+    echo "InitiatorName=iqn.2015-01.com.whamcloud:#{name}#{idx}" > /etc/iscsi/initiatorname.iscsi
+    iscsiadm --mode discoverydb --type sendtargets --portal #{ISCI_IP}:3260 --discover
+    iscsiadm --mode node --targetname iqn.2015-01.com.whamcloud.lu:#{name} --portal #{ISCI_IP}:3260 --login
+    iscsiadm --mode node --targetname iqn.2015-01.com.whamcloud.lu:#{name} --portal #{ISCI_IP}:3260 -o update -n node.startup -v automatic
+    iscsiadm --mode node --targetname iqn.2015-01.com.whamcloud.lu:#{name} --portal #{ISCI_IP}:3260 -o update -n node.conn[0].startup -v automatic
+  SHELL
+end
+
+def fix_hostfile(config)
+  config.vm.provision 'fix-hosts',
+                      type: 'shell',
+                      inline: "sed  -i '/^127.0.0.1\t#{config.vm.hostname}*/d' /etc/hosts"
+end
+
+Vagrant.configure('2') do |config|
+  config.vm.box = 'manager-for-lustre/centos75-1804-base'
+
+  config.vm.provider 'virtualbox' do |vbx|
+    vbx.linked_clone = true
+    vbx.memory = 1024
+    vbx.cpus = 4
+  end
+
+  system("ssh-keygen -t rsa -N '' -f id_rsa") unless File.exist?('id_rsa')
+
+  config.vm.provision 'ssh', type: 'shell', inline: <<-SHELL
+    mkdir -m 0700 -p /root/.ssh
+    cp /vagrant/id_rsa /root/.ssh/.
+    chmod 0600 /root/.ssh/id_rsa
+    mkdir -m 0700 -p /root/.ssh
+    [ -f /vagrant/id_rsa.pub ] && (awk -v pk=\"`cat /vagrant/id_rsa.pub`\" 'BEGIN{split(pk,s,\" \")} $2 == s[2] {m=1;exit}END{if (m==0)print pk}' /root/.ssh/authorized_keys ) >> /root/.ssh/authorized_keys
+    chmod 0600 /root/.ssh/authorized_keys
+
+    cat > /etc/ssh/ssh_config <<__EOF
+    Host *
+      StrictHostKeyChecking no
+__EOF
+  SHELL
+
+  config.vm.define 'iscsi' do |iscsi|
+    iscsi.vm.hostname = 'iscsi.local'
+
+    iscsi.vm.provider 'virtualbox' do |vbx|
+      dir = "#{ENV['HOME']}/VirtualBox\ VMs/vdisks"
+      Dir.mkdir dir unless File.directory?(dir)
+
+      osts = (1..20).map { |x| ["OST#{x}", '5120'] }
+
+      [
+        %w[mgt 512],
+        %w[mdt0 5120]
+      ].concat(osts).each_with_index do |(name, size), i|
+        file_to_disk = "#{dir}/#{name}.vdi"
+        port = (i + 1).to_s
+
+        unless File.exist?(file_to_disk)
+          vbx.customize ['createmedium',
+                         'disk',
+                         '--filename',
+                         file_to_disk,
+                         '--size',
+                         size,
+                         '--format',
+                         'VDI',
+                         '--variant',
+                         'fixed']
+        end
+
+        vbx.customize ['storageattach', :id,
+                       '--storagectl', 'SATA Controller',
+                       '--port', port,
+                       '--type', 'hdd',
+                       '--medium', file_to_disk,
+                       '--device', '0']
+
+        vbx.customize ['setextradata', :id,
+                       "VBoxInternal/Devices/ahci/0/Config/Port#{port}/SerialNumber",
+                       name.ljust(20, '0')]
+      end
+
+      # Lustre / application network
+      iscsi.vm.network 'private_network',
+                       ip: ISCI_IP,
+                       netmask: '255.255.255.0'
+
+      ost_commands = ('d'..'z')
+                     .take(20)
+                     .flat_map.with_index do |x, i|
+                       [
+                         "targetcli /backstores/block create ost#{i + 1} /dev/sd#{x}",
+                         "targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/luns/ create /backstores/block/ost#{i + 1}"
+                       ]
+                     end
+                     .join "\n"
+
+      iscsi.vm.provision 'bootstrap', type: 'shell', inline: <<-SHELL
+        yum -y install targetcli lsscsi
+        targetcli /backstores/block create mgt1 /dev/sdb
+        targetcli /backstores/block create mdt1 /dev/sdc
+        targetcli /iscsi set global auto_add_default_portal=false
+        targetcli /iscsi create iqn.2015-01.com.whamcloud.lu:mds
+        targetcli /iscsi create iqn.2015-01.com.whamcloud.lu:oss
+        targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/luns/ create /backstores/block/mgt1
+        targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/luns/ create /backstores/block/mdt1
+        #{ost_commands}
+        targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/portals/ create #{ISCI_IP}
+        targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/portals/ create #{ISCI_IP}
+        targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/acls create iqn.2015-01.com.whamcloud:mds1
+        targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:mds/tpg1/acls create iqn.2015-01.com.whamcloud:mds2
+        targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/acls create iqn.2015-01.com.whamcloud:oss1
+        targetcli /iscsi/iqn.2015-01.com.whamcloud.lu:oss/tpg1/acls create iqn.2015-01.com.whamcloud:oss2
+        systemctl enable target
+      SHELL
+
+      fix_hostfile iscsi
+
+      provision_mdns iscsi
+    end
+  end
+
+  #
+  # Create an admin server for the cluster
+  #
+  config.vm.define 'adm', primary: true do |adm|
+    adm.vm.hostname = 'adm.local'
+
+    adm.vm.network 'forwarded_port', guest: 443, host: 8443
+    adm.vm.network 'forwarded_port', guest: 8080, host: 8081
+
+    # Admin / management network
+    adm.vm.network 'private_network',
+                   ip: "#{MGMT_NET_PFX}.10",
+                   netmask: '255.255.255.0'
+
+    fix_hostfile adm
+
+    provision_mdns adm
+
+    # Install IML onto the admin node
+    # This requires you have the IML source tree available at
+    # /integrated-manager-for-lustre
+    adm.vm.provision 'install-iml', type: 'shell', run: 'never', inline: <<-SHELL
+      yum-config-manager --add-repo=https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/modulize-rebased/chroma_support.repo
+      yum install -y rpmdevtools git ed epel-release python-setuptools
+      cd /integrated-manager-for-lustre
+      make rpms
+      yum install -y /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-*
+      chroma-config setup admin lustre localhost
+    SHELL
+  end
+
+  #
+  # Create the metadata servers (HA pair)
+  #
+  (1..2).each do |i|
+    config.vm.define "mds#{i}" do |mds|
+      mds.vm.hostname = "mds#{i}.local"
+
+      # Lustre / application network
+      mds.vm.network 'private_network',
+                     ip: "#{LNET_PFX}.1#{i}",
+                     netmask: '255.255.255.0'
+
+      # Admin / management network
+      mds.vm.network 'private_network',
+                     ip: "#{MGMT_NET_PFX}.1#{i}",
+                     netmask: '255.255.255.0'
+
+      # Private network to simulate crossover.
+      # Used exclusively as additional cluster network
+      mds.vm.network 'private_network',
+                     ip: "#{SUBNET_PREFIX}.#{xnet_idx}.1#{i}",
+                     netmask: '255.255.255.0',
+                     auto_config: false
+
+      # Increment the "crossover" subnet number so that
+      # each HA pair has a unique "crossover" subnet
+      xnet_idx += 1 if i.even?
+
+      fix_hostfile mds
+
+      provision_mdns mds
+
+      provision_iscsi_client mds, 'mds', i
+
+      cleanup_storage_server mds
+    end
+  end
+
+  #
+  # Create the object storage servers (OSS)
+  # Servers are configured in HA pairs
+  # By default, only the first 2 nodes are created
+  # To instantiate oss3 and oss4, use this command:
+  #   vagrant up oss{3,4}
+  #
+  (1..4).each do |i|
+    config.vm.define "oss#{i}",
+                     autostart: i <= 2 do |oss|
+
+      oss.vm.hostname = "oss#{i}.local"
+
+      # Lustre / application network
+      oss.vm.network 'private_network',
+                     ip: "#{LNET_PFX}.2#{i}",
+                     netmask: '255.255.255.0'
+
+      # Admin / management network
+      oss.vm.network 'private_network',
+                     ip: "#{MGMT_NET_PFX}.2#{i}",
+                     netmask: '255.255.255.0'
+
+      # Private network to simulate crossover.
+      # Used exclusively as additional cluster network
+      oss.vm.network 'private_network',
+                     ip: "#{SUBNET_PREFIX}.#{xnet_idx}.2#{i}",
+                     netmask: '255.255.255.0',
+                     auto_config: false
+
+      # Increment the "crossover" subnet number so that
+      # each HA pair has a unique "crossover" subnet
+      xnet_idx += 1 if i.even?
+
+      fix_hostfile oss
+
+      provision_mdns oss
+
+      cleanup_storage_server oss
+
+      provision_iscsi_client oss, 'oss', i
+    end
+  end
+
+  # # Create a set of compute nodes.
+  # # By default, only 2 compute nodes are created.
+  # # The configuration supports a maximum of 8 compute nodes.
+  (1..8).each do |c_idx|
+    config.vm.define "c#{c_idx}",
+                     autostart: c_idx <= 2 do |c|
+      c.vm.hostname = "c#{c_idx}.local"
+
+      # Admin / management network
+      c.vm.network 'private_network',
+                   ip: "#{MGMT_NET_PFX}.3#{c_idx}",
+                   netmask: '255.255.255.0'
+
+      # Lustre / application network
+      c.vm.network 'private_network',
+                   ip: "#{LNET_PFX}.3#{c_idx}",
+                   netmask: '255.255.255.0'
+    end
+  end
+end


### PR DESCRIPTION
Create a sandbox for IML dev.

The goal of this box is to use a dedicated ISCI server
which we will add mpath to in a future revision.

Ideally, we can use this setup to test Vendor storage plugins.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>