### PR TITLE
Add install_lustre<zfs|ldiskfs> functions

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -110,7 +110,22 @@ def configure_lustre_network(config)
     systemctl enable ntpd;
     modprobe lnet
     lnetctl lnet configure
+    lnetctl net del --net tcp0
     lnetctl net add --net tcp0 --if eth1
+  SHELL
+end
+
+def install_lustre_zfs(config)
+  config.vm.provision 'install-lustre-zfs', type: 'shell', run: 'never', inline: <<-SHELL
+    yum clean all
+    yum install -y lustre-zfs
+  SHELL
+end
+
+def install_lustre_ldiskfs(config)
+  config.vm.provision 'install-lustre-ldiskfs', type: 'shell', run: 'never', inline: <<-SHELL
+    yum clean all
+    yum install -y lustre-ldiskfs
   SHELL
 end
 
@@ -304,6 +319,10 @@ __EOF
       cleanup_storage_server mds
 
       configure_lustre_network mds
+
+      install_lustre_zfs mds
+
+      install_lustre_ldiskfs mds
     end
   end
 
@@ -357,6 +376,10 @@ __EOF
       cleanup_storage_server oss
 
       configure_lustre_network oss
+
+      install_lustre_zfs oss
+
+      install_lustre_ldiskfs oss
     end
   end
 


### PR DESCRIPTION
- Add install lustre zfs function
- Add install lustre ldiskfs function
- Include the above functions as provision scripts to each of the mds's
and oss's
- Update configure_lustre_network to ensure that all tcp interfaces are
removed before adding eth1

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>