### PR TITLE
iml-sandbox updates

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -42,7 +42,7 @@ def provision_mgmt_net(config, num)
   config.vm.network 'private_network',
                     ip: "#{MGMT_NET_PFX}.#{num}",
                     netmask: '255.255.255.0',
-                    virtualbox__intnet: 'adm-net'
+                    name: 'vboxnet0'
 end
 
 def provision_mpath(config)
@@ -105,13 +105,16 @@ def fix_hostfile(config)
 end
 
 def configure_lustre_network(config)
-  config.vm.provision 'configure-lustre-network', type: 'shell', run: 'never', inline: <<-SHELL
-    systemctl start ntpd;
-    systemctl enable ntpd;
-    modprobe lnet
-    lnetctl lnet configure
-    lnetctl net add --net tcp0 --if eth1
-  SHELL
+  config.vm.provision 'configure-lustre-network',
+                      type: 'shell',
+                      run: 'never',
+                      inline: <<-SHELL
+                        modprobe lnet
+                        lnetctl lnet configure
+                        lnetctl net add --net tcp0 --if eth1
+                        lnetctl net show --net tcp > /etc/lnet.conf
+                        systemctl enable lnet.service
+                      SHELL
 end
 
 def install_lustre_zfs(config)
@@ -129,9 +132,16 @@ def install_lustre_ldiskfs(config)
   SHELL
 end
 
-def get_mds_block_device(size)
-  <<-SHELL
-    echo '"Stream"' | socat - UNIX-CONNECT:/var/run/device-scanner.sock | jq -r '.blockDevices | to_entries | map(.value) | map(select(.isMpath)) | map(select(.size | tonumber == '#{size}')) | map(.paths | .[2]) | .[]'
+def install_ldiskfs_no_iml(config)
+  config.vm.provision 'install-ldiskfs-no-iml', type: 'shell', run: 'never', inline: <<-SHELL
+    yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/latest-release/el7/server
+    yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
+    yum-config-manager --save --setopt='*.gpgcheck=1' downloads.whamcloud.com_public_e2fsprogs_latest_el7_
+    yum-config-manager --save --setopt='*.gpgcheck=0' downloads.whamcloud.com_public_e2fsprogs_latest_el7_
+    yum-config-manager --save --setopt='*.gpgcheck=1' downloads.whamcloud.com_public_lustre_latest-release_el7_server
+    yum-config-manager --save --setopt='*.gpgcheck=0' downloads.whamcloud.com_public_lustre_latest-release_el7_server
+    yum install -y lustre kmod-lustre-osd-ldiskfs ntp
+    systemctl enable --now ntpd
   SHELL
 end
 
@@ -272,7 +282,7 @@ __EOF
     adm.vm.provision 'install-iml-devel-copr', type: 'shell', run: 'never', inline: <<-SHELL
       yum-config-manager --add-repo=https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/master/chroma_support.repo
       yum install -y python2-iml-manager
-      chroma-config setup admin lustre localhost
+      chroma-config setup admin lustre localhost --no-dbspace-check
     SHELL
 
     # Install IML onto the admin node
@@ -336,17 +346,28 @@ __EOF
 
       install_lustre_ldiskfs mds
 
-      disk_size = (i == 1 ? '536870912' : '5368709120')
+      install_ldiskfs_no_iml mds
+
       pool_name = (i == 1 ? 'mgs' : 'mds')
 
-      config.vm.provision 'create-pools', 
-                          type: 'shell', 
-                          run: 'never', 
-                          env: { "device_query" => get_mds_block_device(disk_size) },
+      config.vm.provision 'create-pools',
+                          type: 'shell',
+                          run: 'never',
                           inline: <<-SHELL
-                            block_device=$(eval $device_query)
-                            zpool create #{pool_name} -o multihost=on $block_device
+                            zpool create #{pool_name} -o multihost=on /dev/#{pool_name}
                           SHELL
+
+      config.vm.provision 'add_udev_rule',
+                          type: 'shell',
+                          inline:
+<<-SHELL
+  cat > /etc/udev/rules.d/99-lustre-volume.rules <<EOF
+  SUBSYSTEM=="block", ATTR{size}=="1048576", SYMLINK+="mgt"
+  SUBSYSTEM=="block", ATTR{size}=="10485760", SYMLINK+="mdt"
+EOF
+
+  udevadm trigger --action=change --subsystem-match=block
+SHELL
 
       if i == 1
         config.vm.provision 'create-zfs-fs',
@@ -361,14 +382,12 @@ __EOF
         config.vm.provision 'create-ldiskfs-fs',
                             type: 'shell',
                             run: 'never',
-                            env: { "device_query" => get_mds_block_device(disk_size) },
                             inline: <<-SHELL
                               mkdir -p /mnt/mgs
-                              block_device=$(eval $device_query)
-                              mkfs.lustre --mgs --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp $block_device
-                              mount -t lustre $block_device /mnt/mgs
+                              mkfs.lustre --mgs --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp /dev/mgt
+                              mount -t lustre /dev/mgt /mnt/mgs
                             SHELL
-                            
+
       else
         config.vm.provision 'create-zfs-fs',
                             type: 'shell',
@@ -382,12 +401,10 @@ __EOF
         config.vm.provision 'create-ldiskfs-fs',
                             type: 'shell',
                             run: 'never',
-                            env: { "device_query" => get_mds_block_device(disk_size) },
                             inline: <<-SHELL
                               mkdir -p /mnt/mds
-                              block_device=$(eval $device_query)
-                              mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=0 --mgsnode=10.73.20.11@tcp --fsname=fs $block_device
-                              mount -t lustre $block_device /mnt/mds
+                              mkfs.lustre --mdt --reformat --servicenode=10.73.20.11@tcp --servicenode=10.73.20.12@tcp --index=0 --mgsnode=10.73.20.11@tcp --fsname=fs /dev/mdt
+                              mount -t lustre /dev/mds /mnt/mdt
                             SHELL
       end
     end
@@ -446,7 +463,9 @@ __EOF
       install_lustre_zfs oss
 
       install_lustre_ldiskfs oss
-      
+
+      install_ldiskfs_no_iml oss
+
       config.vm.provision 'create-pools',
                           type: 'shell',
                           run: 'never',
@@ -465,6 +484,7 @@ __EOF
                               mkdir -p /lustre/zfsmo/ost00
                               mount -t lustre oss1/ost00 /lustre/zfsmo/ost00
                             SHELL
+
         config.vm.provision 'create-ldiskfs-fs',
                             type: 'shell',
                             run: 'never',


### PR DESCRIPTION
This PR includes a number of updates for the iml-sandbox.

  - Change the admin network from an internal network to a host only
network. This will enable us to integrate with iml running with docker
on the host.
  - Update lustre network config to be persistent between reboots.
  - Add a provisioner to install ldiskfs without IML repos being
present.
  - Add a provisioner to create symlinks for mdt / mgt volumes via udev
rules.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>