### PR TITLE
Set vm name on iscsi and adm

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -516,17 +516,6 @@ def get_oss_block_device(slice, idxOrEmpty)
   SHELL
 end
 
-# Creates a unique name based on the path of the vagrant file and the name of the vm
-def create_name(path, name)
-  prefix = "#{path}_#{name}"
-  prefix.gsub!(/[^-a-z0-9_]/i, "")
-
-  # milliseconds + random number suffix to allow for simultaneous
-  # `vagrant up` of the same box in different dirs
-  name = prefix + "_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
-  name
-end 
-
 def get_vm_name(id)
   out, err = Open3.capture2e("VBoxManage list vms")
 

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -518,8 +518,7 @@ end
 
 def get_vm_name(id)
   out, err = Open3.capture2e("VBoxManage list vms")
-
-  return false if err.exitstatus != 0
+  raise "Unable to list vms" unless err.exitstatus === 0
   
   path = path = File.dirname(__FILE__).split('/').last
   name = out.split(/\n/)
@@ -535,9 +534,10 @@ end
 # This is used as a predicate to create controllers, as vagrant does not provide this
 # functionality by default.
 def controller_exists(name, controller_name)
-  out, err = Open3.capture2e("VBoxManage showvminfo #{name}")
+  return false if name.nil?
 
-  return false if err.exitstatus != 0
+  out, err = Open3.capture2e("VBoxManage showvminfo #{name}")
+  raise "Unable to show vm info for #{name}" unless err.exitstatus === 0
 
   out.split(/\n/)
      .select { |x| x.start_with? 'Storage Controller Name' }

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -518,7 +518,7 @@ end
 
 def get_vm_name(id)
   out, err = Open3.capture2e("VBoxManage list vms")
-  raise "Unable to list vms" unless err.exitstatus === 0
+  raise out unless err.exitstatus === 0
   
   path = path = File.dirname(__FILE__).split('/').last
   name = out.split(/\n/)
@@ -537,7 +537,7 @@ def controller_exists(name, controller_name)
   return false if name.nil?
 
   out, err = Open3.capture2e("VBoxManage showvminfo #{name}")
-  raise "Unable to show vm info for #{name}" unless err.exitstatus === 0
+  raise out unless err.exitstatus === 0
 
   out.split(/\n/)
      .select { |x| x.start_with? 'Storage Controller Name' }

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -59,9 +59,8 @@ __EOF
     provision_iscsi_net iscsi, '10'
 
     iscsi.vm.provider 'virtualbox' do |vbx|
-      path = File.dirname(__FILE__).split('/').last
-      vbx.name = create_name(path, 'iscsi')
-      create_iscsi_disks(vbx)
+      name = get_vm_name("iscsi")
+      create_iscsi_disks(vbx, name)
     end
 
     ost_commands = ('d'..'z')
@@ -528,6 +527,21 @@ def create_name(path, name)
   name
 end 
 
+def get_vm_name(id)
+  out, err = Open3.capture2e("VBoxManage list vms")
+
+  return false if err.exitstatus != 0
+  
+  path = path = File.dirname(__FILE__).split('/').last
+  name = out.split(/\n/)
+     .select { |x| x.start_with? "\"#{path}_#{id}" }
+     .map { |x| x.tr('"', '')}
+     .map { |x| x.split(' ')[0].strip }
+     .first
+
+  name
+end
+
 # Checks if a scsi controller exists.
 # This is used as a predicate to create controllers, as vagrant does not provide this
 # functionality by default.
@@ -543,8 +557,8 @@ def controller_exists(name, controller_name)
 end
 
 # Creates a SATA Controller and attaches 10 disks to it
-def create_iscsi_disks(vbox)
-  unless controller_exists(vbox.name, 'SATA Controller')
+def create_iscsi_disks(vbox, name)
+  unless controller_exists(name, 'SATA Controller')
     vbox.customize ['storagectl', :id,
                     '--name', 'SATA Controller',
                     '--add', 'sata']

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -59,7 +59,8 @@ __EOF
     provision_iscsi_net iscsi, '10'
 
     iscsi.vm.provider 'virtualbox' do |vbx|
-      create_iscsi_disks(vbx, iscsi.vm.hostname)
+      vbx.name = 'iscsi'
+      create_iscsi_disks(vbx)
     end
 
     ost_commands = ('d'..'z')
@@ -100,6 +101,10 @@ __EOF
   #
   config.vm.define 'adm', primary: true do |adm|
     adm.vm.hostname = 'adm.local'
+
+    adm.vm.provider 'virtualbox' do |vbx|
+      vbx.name = 'adm'
+    end
 
     adm.vm.network 'forwarded_port', guest: 443, host: 8443
 
@@ -530,8 +535,8 @@ def controller_exists(name, controller_name)
 end
 
 # Creates a SATA Controller and attaches 10 disks to it
-def create_iscsi_disks(vbox, name)
-  unless controller_exists(name, 'SATA Controller')
+def create_iscsi_disks(vbox)
+  unless controller_exists(vbox.name, 'SATA Controller')
     vbox.customize ['storagectl', :id,
                     '--name', 'SATA Controller',
                     '--add', 'sata']

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -59,7 +59,8 @@ __EOF
     provision_iscsi_net iscsi, '10'
 
     iscsi.vm.provider 'virtualbox' do |vbx|
-      vbx.name = 'iscsi'
+      path = File.dirname(__FILE__).split('/').last
+      vbx.name = create_name(path, 'iscsi')
       create_iscsi_disks(vbx)
     end
 
@@ -101,10 +102,6 @@ __EOF
   #
   config.vm.define 'adm', primary: true do |adm|
     adm.vm.hostname = 'adm.local'
-
-    adm.vm.provider 'virtualbox' do |vbx|
-      vbx.name = 'adm'
-    end
 
     adm.vm.network 'forwarded_port', guest: 443, host: 8443
 
@@ -519,6 +516,17 @@ def get_oss_block_device(slice, idxOrEmpty)
     echo '"Stream"' | socat - UNIX-CONNECT:/var/run/device-scanner.sock | jq -r '.blockDevices | to_entries | map(.value) |  map(select(.isMpath)) | map(.paths | .[2]) | .[#{slice}] | .[#{idxOrEmpty}]'
   SHELL
 end
+
+# Creates a unique name based on the path of the vagrant file and the name of the vm
+def create_name(path, name)
+  prefix = "#{path}_#{name}"
+  prefix.gsub!(/[^-a-z0-9_]/i, "")
+
+  # milliseconds + random number suffix to allow for simultaneous
+  # `vagrant up` of the same box in different dirs
+  name = prefix + "_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
+  name
+end 
 
 # Checks if a scsi controller exists.
 # This is used as a predicate to create controllers, as vagrant does not provide this


### PR DESCRIPTION
Recently I tried halting my vms and bringing them back up again and
noticed that I wasn't able to do so because it could not locate the
iscsi vm based on the hostname. This meant that it could no longer check
to see if the SATA controller exists on the iscsi vm and causes the
"vagrant up iscsi" command to fail. Setting the vbox name to "iscsi" and
then searching for the sata controller using the vbox name instead of
the vm's hostname fixes the problem. I updated the vbox name for the
admin node as well. The mds's and oss's already have their vbox names
set.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>