### PR TITLE
Add --no-dbspace-check to manual install

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -131,7 +131,7 @@ __EOF
                        cd /integrated-manager-for-lustre
                        make rpms
                        yum install -y /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-*
-                       chroma-config setup admin lustre localhost
+                       chroma-config setup admin lustre localhost --no-dbspace-check
                      SHELL
   end
 


### PR DESCRIPTION
When building from source and auto-installing, we don't want to check
for db space limits.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>