### PR TITLE
Fix 5.0 repo and lustre client provisioning script

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -143,7 +143,7 @@ __EOF
     adm.vm.provision 'install-iml-5',
                      type: 'shell', run: 'never',
                      inline: <<-SHELL
-                      yum-config-manager --add-repo=https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/v5.0.0/chroma_support.repo
+                      yum-config-manager --add-repo=https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/v5.0.0.0/chroma_support.repo
                       yum install -y python2-iml-manager
                       chroma-config setup admin lustre localhost --no-dbspace-check
                      SHELL
@@ -392,7 +392,7 @@ SHELL
                           type: 'shell',
                           inline: <<-SHELL
                             yum-config-manager --add-repo https://downloads.whamcloud.com/public/lustre/lustre-2.12.1/el7/client/
-                            yum install -y lustre-client
+                            yum install -y --nogpgcheck lustre-client
                           SHELL
     end
   end


### PR DESCRIPTION
- Fix the 5.0 repo link
- Add --nogpgcheck on install-lustre-client provisioning script so that
the install finishes.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>