### PR TITLE
Monitored ZFS updates

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -328,6 +328,7 @@ SHELL
                           env: { 'device_query' => get_oss_block_devices(slice) },
                           inline: <<-SHELL
                             block_device=$(eval $device_query)
+                            genhostid
                             zpool create oss#{i} -o multihost=on raidz2 $block_device
                           SHELL
 

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -214,6 +214,7 @@ __EOF
                           type: 'shell',
                           run: 'never',
                           inline: <<-SHELL
+                            genhostid
                             zpool create #{pool_name}s -o multihost=on /dev/#{pool_name}t
                           SHELL
 
@@ -497,16 +498,17 @@ def install_ldiskfs_no_iml(config)
   config.vm.provision 'install-ldiskfs-no-iml', type: 'shell', run: 'never', inline: <<-SHELL
     yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-2.12.1/el7/server/
     yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
-    yum install -y lustre kmod-lustre-osd-ldiskfs ntp
+    yum install -y --nogpgcheck lustre kmod-lustre-osd-ldiskfs ntp
     systemctl enable --now ntpd
   SHELL
 end
 
 def install_zfs_no_iml(config)
   config.vm.provision 'install-zfs-no-iml', type: 'shell', run: 'never', inline: <<-SHELL
-    yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-2.12.1/el7/server/
+    yum-config-manager --add-repo=https://downloads.whamcloud.com/public/lustre/lustre-2.12.1/el7/patchless-ldiskfs-server/
     yum-config-manager --add-repo=https://downloads.whamcloud.com/public/e2fsprogs/latest/el7/
-    yum install -y lustre-osd-zfs-mount lustre lustre-zfs-dkms zfs ntp
+    yum-config-manager --add-repo=http://download.zfsonlinux.org/epel/7.6/kmod/x86_64/
+    yum install -y --nogpgcheck lustre zfs kmod-lustre-osd-ldiskfs kmod-lustre-osd-zfs ntp
     systemctl enable --now ntpd
   SHELL
 end


### PR DESCRIPTION
There were a couple of issues while running the monitored zfs test.
- Update create-pools to call genhostid before creating the pool.
- Add --nogpgcheck when installing ldiskfs
- Update repos when installing zfs

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>