### PR TITLE
Copy chroma_support.repo

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -158,6 +158,7 @@ __EOF
                        yum install -y rpmdevtools git ed epel-release python-setuptools
                        cd /integrated-manager-for-lustre
                        make rpms
+                       cp ./chroma_support.repo /etc/yum.repos.d/
                        yum install -y /integrated-manager-for-lustre/_topdir/RPMS/noarch/python2-iml-manager-*
                        chroma-config setup admin lustre localhost --no-dbspace-check
                      SHELL


### PR DESCRIPTION
When performing a local install,
copy the generated chroma_support.repo over to
/etc/yum.repos.d/

Signed-off-by: Joe Grund <jgrund@whamcloud.io>