### PR TITLE
Fix Install Devel provisioning script

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -138,7 +138,7 @@ __EOF
                      type: 'shell', run: 'never',
                      inline: <<-SHELL
                       curl -k -o /etc/yum.repos.d/chroma_support.repo https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/master/tests/framework/chroma_support.repo.in
-                      sed -i ':a;N;$!ba;s/enabled=1/enabled=0/1' /etc/yum.repos.d/chroma_support.repo
+                      sed -i '/[@MFL_COPR_NAME@]/,10d' /etc/yum.repos.d/chroma_support.repo
                       yum copr enable -y managerforlustre/manager-for-lustre-devel
                       yum install -y python2-iml-manager
                       chroma-config setup admin lustre localhost --no-dbspace-check

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -137,7 +137,8 @@ __EOF
     adm.vm.provision 'install-iml-devel',
                      type: 'shell', run: 'never',
                      inline: <<-SHELL
-                      yum-config-manager --add-repo=https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/master/chroma_support.repo
+                      curl -k -o /etc/yum.repos.d/chroma_support.repo https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/master/tests/framework/chroma_support.repo.in
+                      yum copr enable -y managerforlustre/manager-for-lustre-devel
                       yum install -y python2-iml-manager
                       chroma-config setup admin lustre localhost --no-dbspace-check
                      SHELL

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -146,6 +146,7 @@ __EOF
                       echo "gpgcheck=0" >> /etc/yum.repos.d/repos.influxdata*.repo 
                       # Grafana
                       yum-config-manager --add-repo https://packages.grafana.com/oss/rpm
+                      echo "gpgcheck=0" >> /etc/yum.repos.d/packages.grafana*.repo
                       yum install -y python2-iml-manager
                       chroma-config setup admin lustre localhost --no-dbspace-check
                      SHELL

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -138,6 +138,7 @@ __EOF
                      type: 'shell', run: 'never',
                      inline: <<-SHELL
                       curl -k -o /etc/yum.repos.d/chroma_support.repo https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/master/tests/framework/chroma_support.repo.in
+                      sed -i ':a;N;$!ba;s/enabled=1/enabled=0/1' /etc/yum.repos.d/chroma_support.repo
                       yum copr enable -y managerforlustre/manager-for-lustre-devel
                       yum install -y python2-iml-manager
                       chroma-config setup admin lustre localhost --no-dbspace-check

--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -137,9 +137,15 @@ __EOF
     adm.vm.provision 'install-iml-devel',
                      type: 'shell', run: 'never',
                      inline: <<-SHELL
-                      curl -k -o /etc/yum.repos.d/chroma_support.repo https://raw.githubusercontent.com/whamcloud/integrated-manager-for-lustre/master/tests/framework/chroma_support.repo.in
-                      sed -i '/[@MFL_COPR_NAME@]/,10d' /etc/yum.repos.d/chroma_support.repo
+                      yum install -y epel-release 
                       yum copr enable -y managerforlustre/manager-for-lustre-devel
+                      # Extras
+                      yum-config-manager --add-repo http://mirror.centos.org/centos/7/extras/x86_64/
+                      # InfluxDB
+                      yum-config-manager --add-repo https://repos.influxdata.com/centos/7/x86_64/stable/
+                      echo "gpgcheck=0" >> /etc/yum.repos.d/repos.influxdata*.repo 
+                      # Grafana
+                      yum-config-manager --add-repo https://packages.grafana.com/oss/rpm
                       yum install -y python2-iml-manager
                       chroma-config setup admin lustre localhost --no-dbspace-check
                      SHELL


### PR DESCRIPTION
- The install devel provisioning script is currently broken because the
chroma_support.repo file no longer exists on master. This patch pulls
the support.repo file in from the test framework to ensure that both
grafana and influx repos exist. The manager-for-lustre-devel repo is
then added in using copr enable.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>