### PR TITLE
Update if user have no `VirtualBox VMs` folder

### DIFF
--- a/iml-sandbox/Vagrantfile
+++ b/iml-sandbox/Vagrantfile
@@ -668,7 +668,7 @@ def create_iscsi_disks(vbox, name)
   end
 
   dir = "#{ENV['HOME']}/VirtualBox\ VMs/vdisks"
-  Dir.mkdir dir unless File.directory?(dir)
+  system 'mkdir', '-p', dir unless File.directory?(dir)
 
   osts = (1..20).map { |x| ["OST#{x}", '5120'] }
 


### PR DESCRIPTION
Alternative to use 
```
require 'fileutils'
FileUtils.mkdir_p dir
```