### PR TITLE
Create provisioner to load iml-diagnostics db

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,6 +132,11 @@ Vagrant.configure('2') do |config|
                      type: 'shell',
                      run: 'never',
                      path: 'scripts/install_iml_local.sh'
+
+    adm.vm.provision 'load-diagnostics-db',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/load-diagnostics-db.sh'
   end
 
   #

--- a/scripts/load-diagnostics-db.sh
+++ b/scripts/load-diagnostics-db.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+gunzip /tmp/chromadb_*.sql.gz
+chroma-config stop
+
+
+cd /tmp && \
+sudo -u postgres -- pg_dump -U chroma -F p -w -f other-db-bits.sql -t 'chroma_core_series' -t 'chroma_core_sample_*' -t 'chroma_core_logmessage'
+
+sudo -u postgres -- dropdb chroma
+sudo -u postgres -- createdb chroma
+
+cd /tmp && \
+sudo -u postgres -- psql chroma < chromadb_*.sql && \
+sudo -u postgres -- psql chroma < other-db-bits.sql
+
+chroma-config start


### PR DESCRIPTION
Create a new provisioner that will load a iml-diagnostics
db dump onto the adm node.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>