### PR TITLE
Add host deployment provisioner

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -135,6 +135,12 @@ Vagrant.configure('2') do |config|
                      run: 'never',
                      path: 'scripts/install_iml_local.sh'
 
+    adm.vm.provision 'deploy-managed-hosts',
+                     type: 'shell',
+                     run: 'never',
+                     path: 'scripts/deploy_hosts.sh',
+                     args: 'base_managed_patchless'
+
     adm.vm.provision 'load-diagnostics-db',
                      type: 'shell',
                      run: 'never',

--- a/scripts/deploy_hosts.sh
+++ b/scripts/deploy_hosts.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+iml server add --hosts mds[1,2].local,oss[1,2].local --profile $1


### PR DESCRIPTION
Piggybacking off of: https://github.com/whamcloud/integrated-manager-for-lustre/pull/1296

Create a new provisioner that can be used to deploy agents / profiles to
the vagrant cluster.

Signed-off-by: Joe Grund <jgrund@whamcloud.io>