### PR TITLE
Update docker network trigger

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -774,11 +774,15 @@ end
 
 def configure_docker_network(config)
   config.trigger.before :provision, name: 'configure-docker-network-trigger' do |t|
-    t.ruby do |_, _|
+    t.ruby do |_, machine|
       if ARGV[3] == 'configure-docker-network'
         puts 'Copying identify file to job scheduler container.'
         puts `docker ps --format '{{.Names}}' | grep job-scheduler | xargs -I {} docker exec {} sh -c 'mkdir -p /root/.ssh'`
         puts `docker ps --format '{{.Names}}' | grep job-scheduler | xargs -I {} docker cp id_rsa {}:/root/.ssh`
+        puts "Writing authorized keys to #{machine.name}"
+        puts `cat ~/.ssh/id_rsa.pub | ssh -i ./.vagrant/machines/#{machine.name}/virtualbox/private_key vagrant@#{machine.name} \
+             "cat > /tmp/id_rsa.pub && sudo su - -c 'mkdir -p /root/.ssh && touch /root/.ssh/authorized_keys && cat /tmp/id_rsa.pub \
+             >> /root/.ssh/authorized_keys && rm -f /tmp/id_rsa.pub'"`
       end
     end
   end


### PR DESCRIPTION
When developing with docker locally there are some network 
configurations that need to be made to each of the storage server nodes
before they can be added to IML in the docker container. The id_rsa file
is already copied from local ~/.ssh to the job scheduler container.
However, the local public key needs to be copied into the authorized
keys file for each storage server node. This will allow the docker
container to add the storage servers using the existing key feature in
IML.

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>